### PR TITLE
Correct the fold_right implementations with f being CPS'ed.

### DIFF
--- a/src/cps/folds.ml
+++ b/src/cps/folds.ml
@@ -113,13 +113,13 @@ let%expect_test "fold left list" =
   (try
     print_string  (fold_right_cps2 fk list "" Fun.id )
   with | Stack_overflow -> print_endline "Stack overflow!");
-  [%expect {| 1234 |}] 
+  [%expect {| 4321 |}] 
 
   let%expect_test "fold right cps2 (with helper) list" = 
   (try
     print_string  (fold_right_cps2_wh fk list "")
   with | Stack_overflow -> print_endline "Stack overflow!");
-  [%expect {| 1234 |}] 
+  [%expect {| 4321 |}] 
 
   (* проверка на stack overflow*)
    

--- a/src/cps/folds.ml
+++ b/src/cps/folds.ml
@@ -39,11 +39,19 @@ let fold_right_cps1 f l accu =
   helper l Fun.id
 ;;
 
-(* cps fold_right with cps f*)
 let rec fold_right_cps2 f l accu k =
-  match l with 
-  | [] -> k accu
-  | hd :: tl -> f hd accu (fun s1 -> fold_right_cps2 f tl s1 k)
+    match l with 
+    | [] -> k accu
+    | hd :: tl -> fold_right_cps2 f tl accu (fun res_tail -> f hd res_tail k)
+
+let fold_right_cps2_wh f l accu = 
+    let rec helper xs k = 
+        match xs with
+        | [] -> k accu
+        | hd :: tl -> helper tl (fun res_tail -> f hd res_tail k)
+    in 
+    helper l Fun.id
+;;
 
 (*Наблюдение: можно делать через helper, можно без него. Как упражнение, можете
 переписать то, что написано через helper, без него*)
@@ -104,6 +112,12 @@ let%expect_test "fold left list" =
   let%expect_test "fold right cps2 list" = 
   (try
     print_string  (fold_right_cps2 fk list "" Fun.id )
+  with | Stack_overflow -> print_endline "Stack overflow!");
+  [%expect {| 1234 |}] 
+
+  let%expect_test "fold right cps2 (with helper) list" = 
+  (try
+    print_string  (fold_right_cps2_wh fk list "")
   with | Stack_overflow -> print_endline "Stack overflow!");
   [%expect {| 1234 |}] 
 


### PR DESCRIPTION
**Correct the fold_right implementations with f being CPS'ed. Added a version with recursive handler**
  
In your implementation:
- The function f is called with the head (hd) and the current accumulator (accu). 
- The result of f (s1) becomes the new accumulator for processing the tail (tl). 

As was written at [link:](https://courses.cs.cornell.edu/cs3110/2021sp/textbook/hop/fold_right.html) 

> The intuition for why this function is called fold_right is that the way it works is to "fold in" elements of the list from the right to the left, combining each new element using the operator. For example, fold_right (+) [a;b;c] 0 results in evaluation of the expression a+(b+(c+0)). The parentheses associate from the right-most subexpression to the left.

So it should be vise versa.
